### PR TITLE
Show smtp exceptions when poll was created but mail dispatching failed

### DIFF
--- a/demockrazy/settings.py
+++ b/demockrazy/settings.py
@@ -130,7 +130,7 @@ EMAIL_PORT = 25
 EMAIL_USE_TLS = True
 EMAIL_USE_SSL = False
 
-VOTE_MAIL_FROM = "WahlLeitung@mayflower.de"
+VOTE_MAIL_FROM = "wahlleitung@demo.ckrazy"
 VOTE_BASE_URL = 'http://127.0.0.1:8000'
 VOTE_ADMIN_MAIL_SUBJECT= "[democrazy] Poll '%(title)s' created"
 VOTE_ADMIN_MAIL_TEXT = '''

--- a/vote/templates/vote/create.html
+++ b/vote/templates/vote/create.html
@@ -2,4 +2,11 @@
 
 {% block content %}
 <h1>poll created</h1>
+
+{% if errors %}
+  <b>Unfortunately, the following errors were encountered while dispatching mails.</b><br>
+  {% for error in errors %}
+    {{ error }}<br>
+  {% endfor %}
+{% endif %}
 {% endblock %}

--- a/vote/views.py
+++ b/vote/views.py
@@ -111,6 +111,8 @@ def create(request):
                 send_mail_or_print(args, print_only)
             except SMTPException as e:
                 errors.append(str(e))
+            except UnicodeEncodeError as e:
+                errors.append("%s " % voter_mail + str(e))
         return errors
     p_title = request.POST['title']
     p_type = request.POST['type']
@@ -129,8 +131,8 @@ def create(request):
     send_creator_mail(poll, creator_mail, poll.creator_token, not settings.VOTE_SEND_MAILS)
     errors = send_mails_with_tokens(poll, voter_mails, tokens, not settings.VOTE_SEND_MAILS)
     context = {
-        "errors": errors
-    }
+            "errors": errors
+        }
     return render(request, 'vote/create.html', context)
 
 

--- a/vote/views.py
+++ b/vote/views.py
@@ -6,6 +6,7 @@ from django.core.urlresolvers import reverse
 from django.core.mail import send_mail
 from django.db.models import F
 from django.shortcuts import render, get_object_or_404
+from smtplib import SMTPException
 
 from .models import POLL_TYPES, Poll, Choice, Token
 
@@ -108,7 +109,7 @@ def create(request):
                     )
             try:
                 send_mail_or_print(args, print_only)
-            except Exception as e:
+            except SMTPException as e:
                 errors.append(str(e))
         return errors
     p_title = request.POST['title']

--- a/vote/views.py
+++ b/vote/views.py
@@ -93,6 +93,7 @@ def create(request):
 
     def send_mails_with_tokens(poll, voter_mails, tokens, print_only=False):
         token_strings = [token.token_string for token in tokens]
+        errors = []
         for voter_mail in voter_mails:
             poll_url_with_token = settings.VOTE_BASE_URL + reverse('vote:poll', args=(
                 poll.identifier,)) + '?token=' + token_strings.pop()
@@ -105,8 +106,11 @@ def create(request):
                     settings.VOTE_MAIL_FROM,
                     [voter_mail],
                     )
-            send_mail_or_print(args, print_only)
-
+            try:
+                send_mail_or_print(args, print_only)
+            except Exception as e:
+                errors.append(str(e))
+        return errors
     p_title = request.POST['title']
     p_type = request.POST['type']
     if p_type not in POLL_TYPES:
@@ -122,8 +126,11 @@ def create(request):
     choice_objects = create_choice_objects(choices, poll)
     tokens = create_token_objects(poll, len(voter_mails))
     send_creator_mail(poll, creator_mail, poll.creator_token, not settings.VOTE_SEND_MAILS)
-    send_mails_with_tokens(poll, voter_mails, tokens, not settings.VOTE_SEND_MAILS)
-    return render(request, 'vote/create.html')
+    errors = send_mails_with_tokens(poll, voter_mails, tokens, not settings.VOTE_SEND_MAILS)
+    context = {
+        "errors": errors
+    }
+    return render(request, 'vote/create.html', context)
 
 
 def vote(request, poll_identifier):


### PR DESCRIPTION
Currently, mail dispatch errors are not caught, request processing stops and a server error is shown. Nonetheless the poll is already created, and those who received a token can use this token to vote.

This change catches and shows the encountered SMTPExceptions to the poll creator.
The poll creator needs to handle the implications.
